### PR TITLE
Add Debrify to Download Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@
 
 ### Download Manager
 
-- **Download Navi:** A free and Open Source download manager [[Source](https://github.com/TachibanaGeneralLaboratories/download-navi)] [[F-Droid](https://f-droid.org/en/packages/com.tachibana.downloader/)] [[Google play](https://play.google.com/store/apps/details?id=com.tachibana.downloader)]
 - **BiglyBT:** Fully featured open source bittorrent client and remote control [[Source](https://github.com/BiglySoftware/BiglyBT-Android)] [[Website](https://www.biglybt.com/)] [[F-Droid](https://f-droid.org/packages/com.biglybt.android.client/)]
+- **Debrify:** Cross-platform debrid manager for Real-Debrid, Torbox, and PikPak with streaming and download support [[Source](https://github.com/varunsalian/debrify)] [[Website](https://varunsalian.github.io/debrify/)]
+- **Download Navi:** A free and Open Source download manager [[Source](https://github.com/TachibanaGeneralLaboratories/download-navi)] [[F-Droid](https://f-droid.org/en/packages/com.tachibana.downloader/)] [[Google play](https://play.google.com/store/apps/details?id=com.tachibana.downloader)]
 - **TorrServe:** Application for downloading torrents as HTTP files. Torrent connection is done localy. [[Source](https://github.com/YouROK/TorrServe)] [[F-Droid](https://f-droid.org/packages/ru.yourok.torrserve/)]
 
 ### Connectivity


### PR DESCRIPTION
  ## Addition

  Adding Debrify to the Download Manager section.

  ## About Debrify

  - **Source:** https://github.com/varunsalian/debrify
  - **Website:** https://varunsalian.github.io/debrify/
  - **Platforms:** Android, Android TV
  - **License:** Open Source (Flutter)

  Debrify is a cross-platform debrid manager for Real-Debrid, Torbox, and PikPak. It allows users to stream and download content without torrenting on the device. Features include:

  - Built-in video player with streaming support
  - Download manager with queue management
  - Native Android TV support with full D-pad navigation
  - Multi-service support (Real-Debrid, Torbox, PikPak)